### PR TITLE
feat: Integrate ViewModel for state management

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     // Add the dependency for Firebase Firestore (for a future step)
     // This will be used to store user vocabulary and settings.
     implementation(libs.firebase.firestore)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/kotlinxkyle/fan/ui/screens/CompositionBar.kt
+++ b/app/src/main/java/com/kotlinxkyle/fan/ui/screens/CompositionBar.kt
@@ -3,20 +3,27 @@ package com.kotlinxkyle.fan.ui.screens
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kotlinxkyle.fan.data.Sentence
 
 @Composable
-fun CompositionBar(sentence: Sentence) {
+fun CompositionBar(
+    sentence: Sentence,
+    onClearClick: () -> Unit // Add a click handler for the clear action
+) {
     val sentenceText = sentence.words.joinToString(" ") { it.text }
 
     Row(
@@ -26,8 +33,17 @@ fun CompositionBar(sentence: Sentence) {
             .background(Color.LightGray)
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(text = sentenceText, fontSize = 20.sp)
+        Text(
+            text = sentenceText,
+            fontSize = 20.sp,
+            modifier = Modifier.weight(1f),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Button(onClick = onClearClick) {
+            Text(text = "Clear")
+        }
     }
 }

--- a/app/src/main/java/com/kotlinxkyle/fan/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/kotlinxkyle/fan/ui/screens/MainScreen.kt
@@ -1,49 +1,36 @@
 package com.kotlinxkyle.fan.ui.screens
 
-
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.kotlinxkyle.fan.data.Sentence
-import com.kotlinxkyle.fan.data.Word
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.kotlinxkyle.fan.viewmodel.MainViewModel
 
 @Composable
-fun MainScreen() {
-    // This state will eventually be hoisted into a ViewModel
-    var sentence by remember { mutableStateOf(Sentence()) }
-
-    // Dummy data - this will come from the ViewModel later
-    val wordList = listOf(
-        Word("I", "", "pronoun"),
-        Word("want", "", "verb"),
-        Word("a", "", "article"),
-        Word("the", "", "article"),
-        Word("ball", "", "noun"),
-        Word("play", "", "verb"),
-        Word("go", "", "verb"),
-        Word("outside", "", "noun")
-    )
-    val suggestions = listOf(
-        Word("please", "", "interjection"),
-        Word("thank you", "", "interjection")
-    )
+fun MainScreen(
+    mainViewModel: MainViewModel = viewModel()
+) {
+    val uiState by mainViewModel.uiState.collectAsState()
 
     Column(modifier = Modifier.fillMaxSize()) {
-        CompositionBar(sentence = sentence)
-        SuggestionBar(suggestions = suggestions, onSuggestionClick = {
-            // Logic to add suggestion to sentence
-            val newWords = sentence.words + it
-            sentence = sentence.copy(words = newWords)
-        })
-        WordGridView(words = wordList, onWordClick = {
-            // Logic to add word to sentence
-            val newWords = sentence.words + it
-            sentence = sentence.copy(words = newWords)
-        })
+        CompositionBar(
+            sentence = uiState.sentence,
+            onClearClick = { mainViewModel.clearSentence() }
+        )
+        SuggestionBar(
+            suggestions = uiState.suggestions,
+            onSuggestionClick = { word ->
+                mainViewModel.addWordToSentence(word)
+            }
+        )
+        WordGridView(
+            words = uiState.allWords,
+            onWordClick = { word ->
+                mainViewModel.addWordToSentence(word)
+            }
+        )
     }
 }

--- a/app/src/main/java/com/kotlinxkyle/fan/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/kotlinxkyle/fan/viewmodel/MainViewModel.kt
@@ -1,0 +1,70 @@
+package com.kotlinxkyle.fan.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.kotlinxkyle.fan.data.Sentence
+import com.kotlinxkyle.fan.data.Word
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Represents the state of the MainScreen.
+ */
+data class MainUiState(
+    val sentence: Sentence = Sentence(),
+    val suggestions: List<Word> = emptyList(),
+    val allWords: List<Word> = emptyList()
+)
+
+class MainViewModel : ViewModel() {
+
+    // Private mutable state flow
+    private val _uiState = MutableStateFlow(MainUiState())
+    // Public read-only state flow for the UI to observe
+    val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
+
+    init {
+        loadInitialData()
+    }
+
+    private fun loadInitialData() {
+        // In a real app, this would load from a database or network.
+        // For now, we use the same dummy data as before.
+        val wordList = listOf(
+            Word("I", "", "pronoun"),
+            Word("want", "", "verb"),
+            Word("a", "", "article"),
+            Word("the", "", "article"),
+            Word("ball", "", "noun"),
+            Word("play", "", "verb"),
+            Word("go", "", "verb"),
+            Word("outside", "", "noun")
+        )
+        val suggestionsList = listOf(
+            Word("please", "", "interjection"),
+            Word("thank you", "", "interjection")
+        )
+
+        _uiState.value = MainUiState(allWords = wordList, suggestions = suggestionsList)
+    }
+
+    /**
+     * Adds a word to the current sentence.
+     */
+    fun addWordToSentence(word: Word) {
+        _uiState.update { currentState ->
+            val newWords = currentState.sentence.words + word
+            currentState.copy(sentence = Sentence(words = newWords))
+        }
+    }
+
+    /**
+     * Clears all words from the current sentence.
+     */
+    fun clearSentence() {
+        _uiState.update { it.copy(sentence = Sentence()) }
+    }
+
+    // `speakSentence()` and `fetchSuggestions()` will be implemented in a later phase.
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.00"
 googleGms = "4.4.2"
+lifecycleViewmodelCompose = "2.9.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces a `MainViewModel` to manage the UI state for the `MainScreen`.

- **MainViewModel.kt:**
    - Defines `MainUiState` data class to hold the current sentence, suggestions, and all available words.
    - Implements `MainViewModel` inheriting from `androidx.lifecycle.ViewModel`.
    - Uses `MutableStateFlow` and `StateFlow` to expose UI state.
    - Includes `loadInitialData()` to populate with dummy data (to be replaced with actual data sources later).
    - Adds `addWordToSentence()` to append a word to the current sentence.
    - Adds `clearSentence()` to clear the current sentence.

- **MainScreen.kt:**
    - Now receives an instance of `MainViewModel` (using `viewModel()` delegate).
    - Observes `uiState` from the ViewModel using `collectAsState()`.
    - Passes data and event handlers from the ViewModel to `CompositionBar`, `SuggestionBar`, and `WordGridView`.
    - Removed local state management (`remember { mutableStateOf(...) }`) and dummy data.

- **CompositionBar.kt:**
    - Adds an `onClearClick` lambda parameter to handle the clear button action.
    - A "Clear" button is now displayed, which triggers the `clearSentence` function in the ViewModel.

- **build.gradle.kts & libs.versions.toml:**
    - Adds the `androidx.lifecycle:lifecycle-viewmodel-compose` dependency to enable ViewModel usage with Jetpack Compose.